### PR TITLE
add guest-additions iso

### DIFF
--- a/VirtualBox.spec
+++ b/VirtualBox.spec
@@ -46,7 +46,7 @@
 
 Name:       VirtualBox
 Version:    7.0.18
-Release:    1%{?dist}
+Release:    2%{?dist}
 Summary:    A general-purpose full virtualizer for PC hardware
 
 License:    GPLv2 or (GPLv2 and CDDL)
@@ -260,7 +260,7 @@ Group:      System Environment/Base
 Requires:   %{name}-kmod = %{version}
 Provides:   %{name}-kmod-common = %{version}-%{release}
 Requires:   xorg-x11-server-Xorg
-Requires:   xorg-x11-xinit
+Requires:   xorg-x11-xinit wget coreutils
 Provides:   %{name}-guest = %{version}-%{release}
 Obsoletes:  %{name}-guest < %{version}-%{release}
 %if "%(xserver-sdk-abi-requires 2>/dev/null)"
@@ -739,6 +739,8 @@ getent passwd vboxadd >/dev/null || \
 /sbin/ldconfig
 %systemd_post vboxclient.service
 %systemd_post vboxservice.service
+mkdir -p /usr/share/virtualbox/
+wget "https://download.virtualbox.org/virtualbox/7.0.18/VBoxGuestAdditions_7.0.18.iso" -O /usr/share/virtualbox/VBoxGuestAdditions.iso
 
 #chcon -u system_u -t mount_exec_t "$lib_path/$PACKAGE/mount.vboxsf" > /dev/null 2>&1
 # for i in "$lib_path"/*.so
@@ -757,6 +759,7 @@ getent passwd vboxadd >/dev/null || \
 %preun guest-additions
 %systemd_preun vboxclient.service
 %systemd_preun vboxservice.service
+rm -rf /usr/share/virtualbox/
 
 %postun guest-additions
 /sbin/ldconfig


### PR DESCRIPTION
what is the point of making a guest-additions package?

if the iso of the additions is not in it

has nothing because Virtualbox says that the iso is not

and when clicked on download

he says who can't record it normal

it's in Debian and Ubuntu since 2018 though

https://salsa.debian.org/pkg-virtualbox-team/virtualbox-guest-additions-iso

https://salsa.debian.org/pkg-virtualbox-team/virtualbox-guest-additions-iso/-/blob/master/debian/rules